### PR TITLE
removed text shadow on buttons, and related :none overrides

### DIFF
--- a/sass/config/_mixins.scss
+++ b/sass/config/_mixins.scss
@@ -184,11 +184,9 @@
 	border: 1px solid rgba(0,0,0,.15);
 	@if $isLight{
 		@include gradient($base_color, darken($base_color, 5%));
-		text-shadow: #ffffff 1px 1px 0;
 	}
 	@else{
 		@include gradient($base_color, darken($base_color, 10%));
-		text-shadow: mix(#000000, $base_color, 20%) -1px -1px 0;
 	}
 }
 @mixin button_color_hover($base_color, $isLight: false){
@@ -475,7 +473,6 @@
 
 @mixin button_primary_color($base_color){
 	@include gradient($base_color, darken($base_color, 10%));
-	text-shadow: mix(#000000, $base_color, 20%) -1px -1px 0;
 	@include box-shadow(mix(#ffffff, $base_color, 30%), 1px, 1px, 0, 0, true);
 	border: 1px solid darken($base_color, 20%);
 	&:hover {
@@ -491,7 +488,6 @@
 
 @mixin button_secondary_color($base_color){
 	@include gradient($base_color, darken($base_color, 7.5%));
-	text-shadow: mix(#ffffff, $base_color, 20%) 1px 1px 0;
 	@include box-shadow(mix(#ffffff, $base_color, 30%), 1px, 1px, 0, 0, true);
 	border: 1px solid darken($base_color, 10%);
 	&:hover {
@@ -508,18 +504,15 @@
 @mixin button_disabled_color($base_color){
 	@include gradient($base_color, darken($base_color, 10%));
 	@include box-shadow(mix(#ffffff, $base_color, 30%), 1px, 1px, 0, 0, true);
-	text-shadow: mix(#000000, $base_color, 20%) -1px -1px 0;
 	border: 1px solid darken($base_color, 20%);
 	&:hover {
 			@include gradient($base_color, darken($base_color, 10%));
 			@include box-shadow(mix(#ffffff, $base_color, 30%), 1px, 1px, 0, 0, true);
-			text-shadow: mix(#000000, $base_color, 20%) -1px -1px 0;
 			border: 1px solid darken($base_color, 20%);
 	}
 	&:active {
 			@include gradient($base_color, darken($base_color, 10%));
 			@include box-shadow(mix(#ffffff, $base_color, 30%), 1px, 1px, 0, 0, true);
-			text-shadow: mix(#000000, $base_color, 20%) -1px -1px 0;
 			border: 1px solid darken($base_color, 20%);
 	}
 }
@@ -529,7 +522,6 @@
 	display: inline-block;
 	$darker: $base_color - #444;
 	@include gradient($base_color, $darker);
-	text-shadow: darken($base_color, 35%) 0 0 3px;
 	border: 2px solid $darker;
 	text-decoration: none;
 	text-align: center;
@@ -543,7 +535,6 @@
 	$lighter_base_color: $base_color + #0a0a0a;
 	$darker: $lighter_base_color - #444;
 	@include gradient($lighter_base_color, $darker);
-	text-shadow: none;
 	border: 2px solid $darker;
 	text-decoration: none; }
 

--- a/sass/sassquatch/lib/_forms.scss
+++ b/sass/sassquatch/lib/_forms.scss
@@ -240,14 +240,12 @@ input[type=submit], button, .button, .button-light, a.button {
     &.disabled {
         @include button_disabled_color( $C_gray_lighter );
         color: $C_text_less !important;
-        text-shadow: none !important;
     }
     &[disabled].primary,
     &[disabled="disabled"].primary,
     &.disabled.primary {
         @include button_disabled_color( lighten(desaturate($C_red, 20%), 25%) );
         color: $C_shade !important;
-        text-shadow: none !important;
     }
 }
 

--- a/sass/sassquatch/lib/patterns/_navbuttons.scss
+++ b/sass/sassquatch/lib/patterns/_navbuttons.scss
@@ -1,6 +1,6 @@
 /**
 * NAVBUTTONS
-* buttons uses for navigation purposes, not for taking actions and submitting stuff 
+* buttons uses for navigation purposes, not for taking actions and submitting stuff
 * list filtering, for example
 */
 
@@ -11,7 +11,7 @@
 	padding-left: 0;
 	line-height: 1.5;
     @include inlineblock;
-	@include round($defaultRadius);	
+	@include round($defaultRadius);
 	@include clearfix;
     @include experimental(box-sizing, border-box);
     @include experimental(background-clip, padding-box);
@@ -61,16 +61,16 @@
 		label:first-of-type,
 		li:first-child > a,
 		li:first-child > span {
-			@include round-nw($defaultRadius - 1px);	
-			@include round-ne($defaultRadius - 1px);	
-			@include round-sw(0);	
+			@include round-nw($defaultRadius - 1px);
+			@include round-ne($defaultRadius - 1px);
+			@include round-sw(0);
 		}
 		label:last-of-type
 		li:last-child > a,
 		li:last-child > span {
-			@include round-ne(0);	
-			@include round-se($defaultRadius - 1px);	
-			@include round-sw($defaultRadius - 1px);	
+			@include round-ne(0);
+			@include round-se($defaultRadius - 1px);
+			@include round-sw($defaultRadius - 1px);
 		}
     }
 
@@ -88,7 +88,6 @@
 		@include button_personality;
 		@include button_color(#fff, true);
 		border: none;
-		text-shadow: none;
 		color: $C_darkgray_lightest;
 		@include experimental(box-shadow, '#{$highlight}, #{$shadow_e}');
 	}
@@ -106,7 +105,7 @@
 	}
     &.vertical{
 		label,
-		li > a, 
+		li > a,
 		li > span{
 			@include experimental(box-shadow, '#{$highlight}, #{$shadow_s}');
 		}
@@ -117,11 +116,11 @@
 			@include experimental(box-shadow, '#{$highlight}');
 		}
     }
-    
+
     /*****************************
      * COLOR INVERTED
      ****************************/
-    
+
     .inverted &{
         border-color: $C_darkgray;
 		label,
@@ -129,7 +128,6 @@
 		li > span {
 			@include button_color($C_darkgray_lighter, false);
 			border: none;
-			text-shadow: none;
 			color: $C_gray!important;
 		}
 
@@ -160,7 +158,7 @@
 
 
     /*****************************
-     * COLOR SELECTED ITEM 
+     * COLOR SELECTED ITEM
      ****************************/
 
     li, li:first-child, li:last-child{

--- a/sass/sassquatch/lib/patterns/_segmentedcontrol.scss
+++ b/sass/sassquatch/lib/patterns/_segmentedcontrol.scss
@@ -2,10 +2,10 @@
 /* SEGMENTED CONTROL
  * This is a design pattern that should be used for elements that appear as
  * buttons in the UI and have button-like functionality, appearing grouped
- * together and interrelated. 
+ * together and interrelated.
  *
  * The types of elements are typically:
- * 
+ *
  *   <a> .............. Hash modification, changing contents of view below.
  *   <input radio> .... Making a mutually-exclusive choice in a form.
  *   <input checkbox> . Toggling a particular feature.
@@ -16,7 +16,7 @@
  *
  * In order to maintain IE8 compatibility, we need to have slightly different
  * layouts, which means having two classes: one in which we're using a pattern
- * where the immediate children of a segmented control are `.button`, and 
+ * where the immediate children of a segmented control are `.button`, and
  * another where there `.button` are wrapped in a secondary element, particularly
  * to hide extraneous native UI (checkboxes and radio buttons, for ex).
  *
@@ -56,16 +56,15 @@
 	font-size: 14px;
 	line-height: 1.5;
 	white-space: nowrap;
-	text-shadow: none;
 	text-align: center;
 	text-decoration: none;
-	color: $C_text !important; 
+	color: $C_text !important;
 	/* NOTE: Needed because of cascade overrides post-sassquatch in mobile. */
 }
 
 
 /* These next two are sort of nasty selectors--but since this doesn't work
- * in IE8 anyway (border radius not supported), do we care? -j 
+ * in IE8 anyway (border radius not supported), do we care? -j
  */
 .segmented-control-segment:first-child .segmented-control-button {
 	border-radius: $defaultRadius 0 0 $defaultRadius;


### PR DESCRIPTION
Text shadow smears button text and is a faux-3d style that is the opposite of clean. Removing it improves clarity and lets the button typeface shine .
