### PR TITLE
removed transparency-based, too-light border

### DIFF
--- a/sass/sassquatch/lib/_layout.scss
+++ b/sass/sassquatch/lib/_layout.scss
@@ -69,7 +69,6 @@
 	background-color: #fff;
 	margin-bottom: $baseline;
 	border: 1px solid $C_line;
-    border-color: rgba(0,0,0,.04);
     @include background-clip(padding);
 
 


### PR DESCRIPTION
$C_line (#ddd) is the new/old preference, requested by @rxb in updated touchList styles

![touchlist](https://f.cloud.github.com/assets/1885153/1238970/e9d6cbcc-29f2-11e3-9cf0-c7892de41481.png)

this border-color affects the outer touchList border, which is typically a `ul.touchList.doc-box`
