### PR TITLE
input type="file" styling

### DIFF
--- a/sass/core/_forms.scss
+++ b/sass/core/_forms.scss
@@ -39,6 +39,9 @@ category: Forms
 		</div>
 	</fieldset>
 
+	<label for="yourPhoto">File input <span class="error">(needs work)</span></label>
+	<input type="file" id="yourPhoto" name="yourPhoto" />
+
 	<label for="unicorn">Describe your unicorn</label>
 	<textarea name="unicorn"></textarea>
 </form>
@@ -190,8 +193,7 @@ select[multiple] {
 
 input[type=file] {
 	background-color: #fff;
-	padding: initial;
-	border: initial;
+	padding: $spacing/3;
 	*height: auto;
 	*margin-top: 4px; /* IE7 - helps alignment with inline-style labels */
 }
@@ -281,7 +283,7 @@ name: errors
 parent: formsBase
 ---
 
-Required field labels can be marked as required with the `required` class. 
+Required field labels can be marked as required with the `required` class.
 Error states are applied with an `error` class on the input element.
 
 ```html_example


### PR DESCRIPTION
file inputs are wacky and hate to be styled, and although I would generally lean toward NOT styling them, I am adding this issue because there is a bug filed for it.

Bug:
- https://bugz.meetup.com/show_bug.cgi?id=37161

Resources:
- http://stackoverflow.com/questions/572768/styling-an-input-type-file-button
- http://ericbidelman.tumblr.com/post/14636214755/making-file-inputs-a-pleasure-to-look-at
- http://css-tricks.com/snippets/css/custom-file-input-styling-webkitblink/

If we make a plan here about whether we want to tackle this issue, we can update the bug accordingly.
