### PR TITLE
nowrap for spangled pill label

### DIFF
--- a/sass/util/_pillLabelFactory.scss
+++ b/sass/util/_pillLabelFactory.scss
@@ -15,6 +15,7 @@ $pillBaseSize: 11px;
 	border-radius: $defaultRadius;
 	padding: $pillBaseSize/4 $pillBaseSize/2;
 	margin-right: $pillBaseSize/4;
+	white-space: nowrap;
 }
 
 


### PR DESCRIPTION
fixes #243 

not setting inline-block so that someone can use tags for the right display property (ie. `li`, `.inlineblockList li`, `div`, `span`)
