### PR TITLE
rm duplicated js modifiers

### DIFF
--- a/sass/core/_element_defaults.scss
+++ b/sass/core/_element_defaults.scss
@@ -398,17 +398,4 @@ the whitespace on the bottom).
 	}
 	/* }}} */
 
-
-	/* {{{ Widget helpers (graceful degradation for JS features) */
-	.block-if-js,
-	.inline-if-js,
-	.inline-block-if-js,
-	.hasJS .hide-if-js {	
-		display: none;
-	}
-
-	.hasJS .block-if-js			{ display: block; }
-	.hasJS .inline-if-js		{ display: inline; }
-	.hasJS .inline-block-if-js	{ display: inline-block; }
-	/* }}} */
 }


### PR DESCRIPTION
fixes #206 

(already including these modifiers in `sass/core/_modifiers.scss`)
